### PR TITLE
fix(ENP-4209): deploy filepath in deploy-swan

### DIFF
--- a/scripts/deploy/deploy.ts
+++ b/scripts/deploy/deploy.ts
@@ -29,7 +29,14 @@ execSync(
   `cd ${tmp} && git clone --single-branch --branch master https://projects:${env.DEPLOY_SWAN_TOKEN}@${env.DEPLOY_SWAN_REPOSITORY} ${repoName}`,
 );
 
-const filePath = path.join(tmp, repoName, env.DEPLOY_ENVIRONMENT, "Chart.yaml");
+const filePath = path.join(
+  tmp,
+  repoName,
+  env.DEPLOY_APP_NAME,
+  "argocd",
+  env.DEPLOY_ENVIRONMENT,
+  "Chart.yaml",
+);
 
 const file = fs.readFileSync(filePath, "utf-8");
 


### PR DESCRIPTION
Fixes deploy script

# What happened

## Previous state

it was updating `deploy-swan/master/url-shortener-values.yaml` which is a symlink to `deploy-swan/url-shortener/argocd/master/url-shortener-values.yaml`

---

## Faulty state

I was updating `.deploy-swan/master/Chart.yaml` instead of `deply-swan/url-shortener/argocd/master/Chart.yaml` since there's no chart.yaml symlink

## Fixed state

I'm now targeting `deploy-swan/url-shortener/argocd/master/Chart.yaml` without any symlink usage