### PR TITLE
fix(deps): patch GHSA-wmrf-hv6w-mr66 in kysely

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     ]
   },
   "dependencies": {
+    "@bloodyowl/boxed": "3.4.0",
     "@fastify/schedule": "6.0.0",
     "@fastify/sensible": "6.0.3",
     "@fastify/type-provider-typebox": "5.1.0",
@@ -65,14 +66,13 @@
     "@opentelemetry/sdk-trace-node": "1.30.1",
     "@opentelemetry/semantic-conventions": "1.30.0",
     "@sinclair/typebox": "0.34.25",
-    "@bloodyowl/boxed": "3.4.0",
     "close-with-grace": "2.2.0",
     "dayjs": "1.11.13",
     "dotenv": "16.4.7",
     "fastify": "5.2.1",
     "fastify-metrics": "12.1.0",
     "fastify-plugin": "5.0.1",
-    "kysely": "0.27.5",
+    "kysely": "0.28.14",
     "pg": "8.13.3",
     "picocolors": "1.1.1",
     "pino-pretty": "13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 5.0.1
         version: 5.0.1
       kysely:
-        specifier: 0.27.5
-        version: 0.27.5
+        specifier: 0.28.14
+        version: 0.28.14
       pg:
         specifier: 8.13.3
         version: 8.13.3
@@ -1371,9 +1371,9 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
-  kysely@0.27.5:
-    resolution: {integrity: sha512-s7hZHcQeSNKpzCkHRm8yA+0JPLjncSWnjb+2TIElwS2JAqYr+Kv3Ess+9KFfJS0C1xcQ1i9NkNHpWwCYpHMWsA==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.14:
+    resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
+    engines: {node: '>=20.0.0'}
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
@@ -3029,7 +3029,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  kysely@0.27.5: {}
+  kysely@0.28.14: {}
 
   light-my-request@6.6.0:
     dependencies:


### PR DESCRIPTION
## Security fix

| Field | Value |
|---|---|
| **GHSA** | GHSA-wmrf-hv6w-mr66, GHSA-8cpq-38p9-67gx |
| **Severity** | HIGH |
| **Package** | kysely |
| **Vulnerable** | < 0.28.14 |
| **Fixed** | 0.28.14 |

### What is the vulnerability?

SQL Injection via unsanitized JSON path keys when ignoring/silencing compilation errors or using `Kysely<any>`. Also includes MySQL SQL Injection via Insufficient Backslash Escaping in `sql.lit(string)` and similar methods.

### What does this PR do?

Bumps `kysely` from `0.27.5` to `0.28.14`, the minimum version that resolves both advisories.

### Verification

- [x] pnpm typecheck
- [x] pnpm build
- [x] pnpm test
